### PR TITLE
fix: make stoppable when adding time beyond the configured max

### DIFF
--- a/src/components/app.vue
+++ b/src/components/app.vue
@@ -85,7 +85,7 @@ export default {
       return !this.interval && this.value > 0;
     },
     stoppable() {
-      return !this.interval && this.value < this.currentMax;
+      return !this.interval && this.value != this.max;
     }
   },
   created() {


### PR DESCRIPTION
As discussed in chat.

I also went and changed the comparison to work on max instead of currentMax because when using '!=' with currentMax it wasn't stoppable until the timer had been running for 1 second. If it were resetting to currentMax that might make sense, but it was a little unintuitive/surprising for it to work that way when it's always resetting to max.